### PR TITLE
Implement #33: Open redirect in login flow via returnUrl query parameter

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -99,16 +99,30 @@ async function doLogin() {
     if (!data) return;
     if (data.token) {
         setToken(data.token, data.username);
-        // Open redirect: reads returnUrl from query string without validation
         const params = new URLSearchParams(window.location.search);
-        const returnUrl = params.get("returnUrl");
-        if (returnUrl) {
-            window.location.href = returnUrl; // open redirect
+        const safeReturnUrl = getSafeReturnUrl(params.get("returnUrl"));
+        if (safeReturnUrl) {
+            window.location.href = safeReturnUrl;
         } else {
             showNotes();
         }
     } else {
         document.getElementById("login-error").textContent = data.detail || "Login failed";
+    }
+}
+
+function getSafeReturnUrl(rawReturnUrl) {
+    if (!rawReturnUrl) return null;
+    if (!rawReturnUrl.startsWith("/") || rawReturnUrl.startsWith("//") || rawReturnUrl.includes("\\")) {
+        return null;
+    }
+
+    try {
+        const url = new URL(rawReturnUrl, window.location.origin);
+        if (url.origin !== window.location.origin) return null;
+        return `${url.pathname}${url.search}${url.hash}`;
+    } catch (e) {
+        return null;
     }
 }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,25 @@
+import atexit
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
 from fastapi.testclient import TestClient
 
-from app import app
+_db_fd, _db_path = tempfile.mkstemp(prefix="notekeeper-test-", suffix=".db")
+os.close(_db_fd)
+os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
+atexit.register(lambda: os.path.exists(_db_path) and os.unlink(_db_path))
 
+from app import app
+from database import init_db
+
+init_db()
 client = TestClient(app)
+APP_JS = Path(__file__).resolve().parents[1] / "static" / "js" / "app.js"
 
 
 def test_register():
@@ -28,3 +45,53 @@ def test_create_note():
 def test_calc():
     resp = client.post("/calc", json={"expression": "2 + 2"})
     assert resp.json()["result"] == 4
+
+
+def test_login_return_url_validation_removes_direct_redirect():
+    app_js = APP_JS.read_text()
+
+    assert "window.location.href = returnUrl" not in app_js
+    assert "function getSafeReturnUrl" in app_js
+    assert "new URL(rawReturnUrl, window.location.origin)" in app_js
+    assert 'rawReturnUrl.startsWith("//")' in app_js
+    assert 'rawReturnUrl.includes("\\\\")' in app_js
+    assert "url.origin !== window.location.origin" in app_js
+
+
+def test_login_return_url_validation_cases():
+    if not shutil.which("node"):
+        pytest.skip("node is required for frontend helper regression coverage")
+
+    app_js = APP_JS.read_text()
+    script = f"""
+const vm = require("vm");
+const source = {json.dumps(app_js)};
+const context = {{
+  window: {{ location: {{ origin: "https://app.example", search: "" }} }},
+  localStorage: {{ getItem() {{}}, setItem() {{}}, removeItem() {{}} }},
+  document: {{ getElementById() {{ return {{ innerHTML: "", textContent: "" }}; }} }},
+  console,
+  URL,
+  URLSearchParams
+}};
+vm.createContext(context);
+vm.runInContext(source, context);
+
+const cases = [
+  ["https://evil.com/steal", null],
+  ["//evil.com/steal", null],
+  ["javascript:alert(1)", null],
+  ["/\\\\evil.com/steal", null],
+  ["/", "/"],
+  ["/?search=abc", "/?search=abc"],
+  ["/notes#top", "/notes#top"]
+];
+
+for (const [input, expected] of cases) {{
+  const actual = context.getSafeReturnUrl(input);
+  if (actual !== expected) {{
+    throw new Error(`${{input}} returned ${{actual}}, expected ${{expected}}`);
+  }}
+}}
+"""
+    subprocess.run(["node", "-e", script], check=True)


### PR DESCRIPTION
Implements #33.

Run: `issue-33-20260426-053322-open-redirect-in-login-flow-via-returnur`

Summary:
Implemented the open redirect fix.

Changed:
- `static/js/app.js`: `doLogin()` now routes `returnUrl` through `getSafeReturnUrl()`, accepting only slash-prefixed same-origin relative paths and rejecting absolute, protocol-relative, `javascript:`, decoded backslash, malformed, or external values.
- `tests/test_app.py`: added regression coverage for unsafe absolute/protocol-relative values and safe relative values. Also made tests use an isolated temporary SQLite DB so the suite runs cleanly.

Verification:
- `git diff --check` passed.
- Full pytest suite passed: `6 passed`.

Note: `pytest` needed an environment workaround because the global Python 3.11 pytest install is missing dependencies; I verified with Python 3.12 app deps and pytest loaded from the existing 3.11 package path.

Verification artifact: `.gg/runs/issue-33-20260426-053322-open-redirect-in-login-flow-via-returnur/artifacts/integration-verification.json`
