### PR TITLE
Implement #3: CRITICAL: Passwords stored in plaintext, used as auth token

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ def _get_current_user(token: str):
 
 @app.post("/register")
 def register(user: UserCreate):
-    logger.info(f"Registering user: {user.username}, password: {user.password}")
+    logger.info("Registering user: %s", user.username)
     result = register_user(user.username, user.password, user.email)
     if "error" in result:
         raise HTTPException(status_code=400, detail=result["error"])

--- a/auth.py
+++ b/auth.py
@@ -1,4 +1,45 @@
+import hashlib
+import hmac
+import secrets
+
 from database import get_db
+
+
+PASSWORD_HASH_PREFIX = "pbkdf2_sha256"
+PASSWORD_HASH_ITERATIONS = 260_000
+
+
+def _hash_password(password: str) -> str:
+    salt = secrets.token_hex(16)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt.encode("utf-8"),
+        PASSWORD_HASH_ITERATIONS,
+    ).hex()
+    return f"{PASSWORD_HASH_PREFIX}${PASSWORD_HASH_ITERATIONS}${salt}${digest}"
+
+
+def _verify_password(password: str, stored_password: str) -> bool:
+    if not stored_password.startswith(f"{PASSWORD_HASH_PREFIX}$"):
+        return hmac.compare_digest(password, stored_password)
+
+    try:
+        _, iterations, salt, expected_digest = stored_password.split("$", 3)
+        actual_digest = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode("utf-8"),
+            salt.encode("utf-8"),
+            int(iterations),
+        ).hex()
+    except (TypeError, ValueError):
+        return False
+
+    return hmac.compare_digest(actual_digest, expected_digest)
+
+
+def _token_digest(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
 def register_user(username: str, password: str, email: str = None):
@@ -6,7 +47,7 @@ def register_user(username: str, password: str, email: str = None):
     try:
         conn.execute(
             "INSERT INTO users (username, password, email) VALUES (?, ?, ?)",
-            (username, password, email),
+            (username, _hash_password(password), email),
         )
         conn.commit()
         return {"username": username, "status": "created"}
@@ -19,19 +60,39 @@ def register_user(username: str, password: str, email: str = None):
 def login_user(username: str, password: str):
     conn = get_db()
     row = conn.execute(
-        "SELECT * FROM users WHERE username = ? AND password = ?",
-        (username, password),
+        "SELECT * FROM users WHERE username = ?",
+        (username,),
     ).fetchone()
+    if not row or not _verify_password(password, row["password"]):
+        conn.close()
+        return None
+
+    if not row["password"].startswith(f"{PASSWORD_HASH_PREFIX}$"):
+        conn.execute(
+            "UPDATE users SET password = ? WHERE id = ?",
+            (_hash_password(password), row["id"]),
+        )
+
+    token = secrets.token_urlsafe(32)
+    conn.execute(
+        "INSERT INTO auth_tokens (token_hash, user_id) VALUES (?, ?)",
+        (_token_digest(token), row["id"]),
+    )
+    conn.commit()
     conn.close()
-    if row:
-        return {"user_id": row["id"], "username": row["username"], "token": row["password"]}
-    return None
+    return {"user_id": row["id"], "username": row["username"], "token": token}
 
 
 def get_user_by_token(token: str):
     conn = get_db()
     row = conn.execute(
-        "SELECT * FROM users WHERE password = ?", (token,)
+        """
+        SELECT users.id, users.username
+        FROM users
+        JOIN auth_tokens ON auth_tokens.user_id = users.id
+        WHERE auth_tokens.token_hash = ?
+        """,
+        (_token_digest(token),),
     ).fetchone()
     conn.close()
     if row:

--- a/database.py
+++ b/database.py
@@ -26,6 +26,12 @@ def init_db():
             is_public INTEGER DEFAULT 0,
             FOREIGN KEY (user_id) REFERENCES users(id)
         );
+        CREATE TABLE IF NOT EXISTS auth_tokens (
+            token_hash TEXT PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        );
     """)
     conn.commit()
     conn.close()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,13 +1,33 @@
+import logging
+
+import pytest
 from fastapi.testclient import TestClient
 
 from app import app
+import database
+from auth import PASSWORD_HASH_PREFIX
+from database import get_db, init_db
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, "DATABASE_URL", f"sqlite:///{tmp_path / 'test.db'}")
+    init_db()
 
 
 def test_register():
     resp = client.post("/register", json={"username": "testuser", "password": "pass123"})
     assert resp.status_code == 200
+
+    conn = get_db()
+    row = conn.execute(
+        "SELECT password FROM users WHERE username = ?", ("testuser",)
+    ).fetchone()
+    conn.close()
+    assert row["password"] != "pass123"
+    assert row["password"].startswith(f"{PASSWORD_HASH_PREFIX}$")
 
 
 def test_login():
@@ -15,6 +35,20 @@ def test_login():
     resp = client.post("/login", json={"username": "loginuser", "password": "pass123"})
     assert resp.status_code == 200
     assert "token" in resp.json()
+    assert resp.json()["token"] != "pass123"
+
+    conn = get_db()
+    row = conn.execute(
+        "SELECT password FROM users WHERE username = ?", ("loginuser",)
+    ).fetchone()
+    conn.close()
+    assert resp.json()["token"] != row["password"]
+
+
+def test_login_invalid_credentials_returns_401():
+    client.post("/register", json={"username": "invaliduser", "password": "pass123"})
+    resp = client.post("/login", json={"username": "invaliduser", "password": "wrong"})
+    assert resp.status_code == 401
 
 
 def test_create_note():
@@ -23,6 +57,31 @@ def test_create_note():
     token = resp.json()["token"]
     resp = client.post("/notes", json={"title": "Test", "content": "Body"}, headers={"x-token": token})
     assert resp.status_code == 200
+
+    resp = client.get("/notes", headers={"x-token": token})
+    assert resp.status_code == 200
+    assert resp.json()[0]["title"] == "Test"
+
+
+def test_raw_password_rejected_as_token():
+    client.post("/register", json={"username": "rawtokenuser", "password": "pw"})
+    resp = client.post("/login", json={"username": "rawtokenuser", "password": "pw"})
+    token = resp.json()["token"]
+
+    assert client.get("/notes", headers={"x-token": token}).status_code == 200
+    assert client.get("/notes", headers={"x-token": "pw"}).status_code == 401
+
+
+def test_register_does_not_log_password(caplog):
+    caplog.set_level(logging.INFO, logger="app")
+    resp = client.post(
+        "/register",
+        json={"username": "loguser", "password": "do-not-log-this"},
+    )
+
+    assert resp.status_code == 200
+    assert "loguser" in caplog.text
+    assert "do-not-log-this" not in caplog.text
 
 
 def test_calc():


### PR DESCRIPTION
Implements #3.

Run: `issue-3-20260426-061756-critical-passwords-stored-in-plaintext-u`

Summary:
Implemented the auth fix with a small stdlib-only patch.

Changed files:
- [auth.py](/Users/fnt/temp/podlodka-ai-club/.gg-worktrees/gg-test/issue-3-20260426-061756-critical-passwords-stored-in-plaintext-u/candidate-1/auth.py): PBKDF2 password hashing, legacy plaintext verify-and-rehash, random login tokens, hashed token lookup.
- [database.py](/Users/fnt/temp/podlodka-ai-club/.gg-worktrees/gg-test/issue-3-20260426-061756-critical-passwords-stored-in-plaintext-u/candidate-1/database.py): added `auth_tokens`.
- [app.py](/Users/fnt/temp/podlodka-ai-club/.gg-worktrees/gg-test/issue-3-20260426-061756-critical-passwords-stored-in-plaintext-u/candidate-1/app.py): removed password logging.
- [tests/test_app.py](/Users/fnt/temp/podlodka-ai-club/.gg-worktrees/gg-test/issue-3-20260426-061756-critical-passwords-stored-in-plaintext-u/candidate-1/tests/test_app.py): added regression coverage for hashed storage, token/password separation, note access, raw-password rejection, invalid login, and registration logging.

Verification:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /opt/homebrew/opt/python@3.11/bin/python3.11 -c "import sys; sys.path.append('/opt/homebrew/lib/python3.12/site-packages'); import pytest; raise SystemExit(pytest.main(['tests/test_app.py']))"`: `7 passed`.
- `git diff --check`: passed.

Remaining risk: existing issued plaintext-password “tokens” stop working after this change; users need to log in once to receive a new random token. Plain `pytest` is blocked by the host Python environment’s missing global packages/plugins, so I used the isolated command above.

Verification artifact: `.gg/runs/issue-3-20260426-061756-critical-passwords-stored-in-plaintext-u/artifacts/integration-verification.json`
