### PR TITLE
Implement #6: File upload has no validation -- path traversal and arbitrary file types

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,8 @@
 import os
 import logging
+from pathlib import Path
+import re
+import tempfile
 import traceback
 
 from fastapi import FastAPI, File, Header, HTTPException, UploadFile
@@ -9,7 +12,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from auth import get_user_by_token, login_user, register_user
-from config import ADMIN_PASSWORD, DEBUG, UPLOAD_DIR
+from config import (
+    ADMIN_PASSWORD,
+    DEBUG,
+    UPLOAD_ALLOWED_CONTENT_TYPES,
+    UPLOAD_ALLOWED_EXTENSIONS,
+    UPLOAD_DIR,
+    UPLOAD_MAX_BYTES,
+)
 from database import get_db, init_db
 
 logging.basicConfig(level=logging.DEBUG)
@@ -67,6 +77,31 @@ def _get_current_user(token: str):
     if not user:
         raise HTTPException(status_code=401, detail="Invalid token")
     return user
+
+
+def _sanitize_upload_filename(filename: str) -> str:
+    basename = os.path.basename((filename or "").replace("\\", "/")).strip()
+    safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", basename)
+    if not safe_name or safe_name in {".", ".."}:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+    return safe_name
+
+
+def _resolve_upload_destination(filename: str) -> Path:
+    upload_root = Path(UPLOAD_DIR).resolve()
+    destination = (upload_root / filename).resolve()
+    try:
+        destination.relative_to(upload_root)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid upload path")
+    return destination
+
+
+def _validate_upload_file(file: UploadFile, safe_filename: str) -> None:
+    extension = Path(safe_filename).suffix.lower()
+    content_type = (file.content_type or "").split(";", 1)[0].lower()
+    if extension not in UPLOAD_ALLOWED_EXTENSIONS or content_type not in UPLOAD_ALLOWED_CONTENT_TYPES:
+        raise HTTPException(status_code=415, detail="Unsupported file type")
 
 
 @app.post("/register")
@@ -181,12 +216,37 @@ def list_public_notes():
 @app.post("/upload")
 def upload_file(file: UploadFile = File(...), x_token: str = Header(None)):
     _get_current_user(x_token)
-    os.makedirs(UPLOAD_DIR, exist_ok=True)
-    # No file type validation, path traversal possible
-    file_path = os.path.join(UPLOAD_DIR, file.filename)
-    with open(file_path, "wb") as f:
-        f.write(file.file.read())
-    return {"filename": file.filename, "path": file_path}
+    safe_filename = _sanitize_upload_filename(file.filename)
+    _validate_upload_file(file, safe_filename)
+    destination = _resolve_upload_destination(safe_filename)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    temp_path = None
+    bytes_written = 0
+    try:
+        with tempfile.NamedTemporaryFile(
+            "wb",
+            delete=False,
+            dir=destination.parent,
+            prefix=f".{safe_filename}.",
+            suffix=".tmp",
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            while True:
+                chunk = file.file.read(64 * 1024)
+                if not chunk:
+                    break
+                bytes_written += len(chunk)
+                if bytes_written > UPLOAD_MAX_BYTES:
+                    raise HTTPException(status_code=413, detail="File too large")
+                temp_file.write(chunk)
+        os.replace(temp_path, destination)
+    except Exception:
+        if temp_path and temp_path.exists():
+            temp_path.unlink()
+        raise
+
+    return {"filename": safe_filename, "path": str(Path(UPLOAD_DIR) / safe_filename)}
 
 
 @app.post("/calc")

--- a/config.py
+++ b/config.py
@@ -4,4 +4,7 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./notes.db")
 SECRET_KEY = "super-secret-key-12345"
 DEBUG = True
 UPLOAD_DIR = "uploads"
+UPLOAD_ALLOWED_EXTENSIONS = {".gif", ".jpg", ".jpeg", ".png", ".webp"}
+UPLOAD_ALLOWED_CONTENT_TYPES = {"image/gif", "image/jpeg", "image/png", "image/webp"}
+UPLOAD_MAX_BYTES = int(os.getenv("UPLOAD_MAX_BYTES", 2 * 1024 * 1024))
 ADMIN_PASSWORD = "admin123"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,30 +1,133 @@
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
 from fastapi.testclient import TestClient
 
-from app import app
+import app as app_module
 
-client = TestClient(app)
+app_module.init_db()
+client = TestClient(app_module.app)
+
+
+def _register_and_login():
+    username = f"user_{uuid4().hex}"
+    password = f"pw_{uuid4().hex}"
+    resp = client.post("/register", json={"username": username, "password": password})
+    assert resp.status_code == 200
+    resp = client.post("/login", json={"username": username, "password": password})
+    assert resp.status_code == 200
+    return {"x-token": resp.json()["token"]}
 
 
 def test_register():
-    resp = client.post("/register", json={"username": "testuser", "password": "pass123"})
+    resp = client.post(
+        "/register",
+        json={"username": f"testuser_{uuid4().hex}", "password": "pass123"},
+    )
     assert resp.status_code == 200
 
 
 def test_login():
-    client.post("/register", json={"username": "loginuser", "password": "pass123"})
-    resp = client.post("/login", json={"username": "loginuser", "password": "pass123"})
+    username = f"loginuser_{uuid4().hex}"
+    client.post("/register", json={"username": username, "password": "pass123"})
+    resp = client.post("/login", json={"username": username, "password": "pass123"})
     assert resp.status_code == 200
     assert "token" in resp.json()
 
 
 def test_create_note():
-    client.post("/register", json={"username": "noteuser", "password": "pw"})
-    resp = client.post("/login", json={"username": "noteuser", "password": "pw"})
-    token = resp.json()["token"]
-    resp = client.post("/notes", json={"title": "Test", "content": "Body"}, headers={"x-token": token})
+    headers = _register_and_login()
+    resp = client.post(
+        "/notes",
+        json={"title": "Test", "content": "Body"},
+        headers=headers,
+    )
     assert resp.status_code == 200
 
 
 def test_calc():
     resp = client.post("/calc", json={"expression": "2 + 2"})
     assert resp.json()["result"] == 4
+
+
+def test_upload_allows_image_under_upload_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(app_module, "UPLOAD_DIR", str(tmp_path))
+    headers = _register_and_login()
+
+    resp = client.post(
+        "/upload",
+        files={"file": ("avatar.png", b"fake png", "image/png")},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["filename"] == "avatar.png"
+    saved_path = Path(data["path"]).resolve()
+    assert saved_path == (tmp_path / "avatar.png").resolve()
+    assert saved_path.read_bytes() == b"fake png"
+
+
+def test_upload_sanitizes_traversal_filename(tmp_path, monkeypatch):
+    upload_dir = tmp_path / "safe" / "uploads"
+    outside_path = tmp_path / "etc" / "cron.d" / "evil.png"
+    outside_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(app_module, "UPLOAD_DIR", str(upload_dir))
+    headers = _register_and_login()
+
+    resp = client.post(
+        "/upload",
+        files={"file": ("../../etc/cron.d/evil.png", b"fake png", "image/png")},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["filename"] == "evil.png"
+    assert ".." not in data["path"]
+    assert (upload_dir / "evil.png").read_bytes() == b"fake png"
+    assert not outside_path.exists()
+
+
+def test_upload_rejects_unsupported_file_type(tmp_path, monkeypatch):
+    monkeypatch.setattr(app_module, "UPLOAD_DIR", str(tmp_path))
+    headers = _register_and_login()
+
+    resp = client.post(
+        "/upload",
+        files={"file": ("avatar.txt", b"text", "text/plain")},
+        headers=headers,
+    )
+
+    assert resp.status_code == 415
+    assert not (tmp_path / "avatar.txt").exists()
+
+
+def test_upload_rejects_oversized_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(app_module, "UPLOAD_DIR", str(tmp_path))
+    monkeypatch.setattr(app_module, "UPLOAD_MAX_BYTES", 3)
+    headers = _register_and_login()
+
+    resp = client.post(
+        "/upload",
+        files={"file": ("avatar.png", b"too large", "image/png")},
+        headers=headers,
+    )
+
+    assert resp.status_code == 413
+    assert not (tmp_path / "avatar.png").exists()
+
+
+@pytest.mark.parametrize("headers", [{}, {"x-token": "invalid"}])
+def test_upload_requires_valid_token(tmp_path, monkeypatch, headers):
+    monkeypatch.setattr(app_module, "UPLOAD_DIR", str(tmp_path))
+
+    resp = client.post(
+        "/upload",
+        files={"file": ("avatar.png", b"fake png", "image/png")},
+        headers=headers,
+    )
+
+    assert resp.status_code == 401
+    assert not (tmp_path / "avatar.png").exists()


### PR DESCRIPTION
Implements #6.

Run: `issue-6-20260427-094623-file-upload-has-no-validation-path-trave`

Summary:
Implemented the upload hardening patch.

Changed:
- [app.py](/Users/fnt/temp/podlodka-ai-club/.gg-worktrees/gg-test/issue-6-20260427-094623-file-upload-has-no-validation-path-trave/candidate-1/app.py:82): sanitizes upload filenames, validates extension/content type, resolves destination under `UPLOAD_DIR`, streams with max-size enforcement, writes through a temp file, and returns only the sanitized filename/path.
- [config.py](/Users/fnt/temp/podlodka-ai-club/.gg-worktrees/gg-test/issue-6-20260427-094623-file-upload-has-no-validation-path-trave/candidate-1/config.py:7): added allowed image extensions/content types and `UPLOAD_MAX_BYTES`.
- [tests/test_app.py](/Users/fnt/temp/podlodka-ai-club/.gg-worktrees/gg-test/issue-6-20260427-094623-file-upload-has-no-validation-path-trave/candidate-1/tests/test_app.py:54): added regressions for allowed upload, traversal filename, unsupported type, oversized payload, and missing/invalid token.

Verified:
- `tests/test_app.py`: `10 passed`
- `py_compile` on `app.py`, `config.py`, `tests/test_app.py`
- Plain host `pytest` is not usable in this environment due missing host deps/plugins (`certifi`, then `anyio`), so I ran through an existing local FastAPI env with plugin autoload disabled.

Worktree has only the intended modified files plus the pre-existing untracked `.gg-cache/`.

Verification artifact: `.gg/runs/issue-6-20260427-094623-file-upload-has-no-validation-path-trave/artifacts/integration-verification.json`
