### PR TITLE
Implement #7: CORS allows all origins with credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=sqlite:///./notes.db
 SECRET_KEY=change-me-in-production
+ALLOWED_ORIGINS=http://localhost:8000,http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ python -m uvicorn app:app --reload
 
 API: http://localhost:8000
 Docs: http://localhost:8000/docs
+
+## Configuration
+
+`ALLOWED_ORIGINS` is a comma-separated list of browser origins allowed for credentialed CORS requests.

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from auth import get_user_by_token, login_user, register_user
-from config import ADMIN_PASSWORD, DEBUG, UPLOAD_DIR
+from config import ADMIN_PASSWORD, ALLOWED_ORIGINS, DEBUG, UPLOAD_DIR
 from database import get_db, init_db
 
 logging.basicConfig(level=logging.DEBUG)
@@ -27,7 +27,7 @@ def root():
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/config.py
+++ b/config.py
@@ -5,3 +5,11 @@ SECRET_KEY = "super-secret-key-12345"
 DEBUG = True
 UPLOAD_DIR = "uploads"
 ADMIN_PASSWORD = "admin123"
+ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv(
+        "ALLOWED_ORIGINS",
+        "http://localhost:8000,http://localhost:3000",
+    ).split(",")
+    if origin.strip()
+]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,47 @@
 from fastapi.testclient import TestClient
+from fastapi.middleware.cors import CORSMiddleware
 
 from app import app
+from config import ALLOWED_ORIGINS
 
 client = TestClient(app)
+
+
+def test_cors_middleware_uses_configured_origins_without_wildcard_credentials():
+    middleware = next(item for item in app.user_middleware if item.cls is CORSMiddleware)
+    options = getattr(middleware, "kwargs", getattr(middleware, "options", {}))
+
+    assert options["allow_credentials"] is True
+    assert options["allow_origins"] == ALLOWED_ORIGINS
+    assert options["allow_origins"] != ["*"]
+
+
+def test_cors_preflight_allows_configured_origin():
+    origin = ALLOWED_ORIGINS[0]
+    resp = client.options(
+        "/notes",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == origin
+    assert resp.headers["access-control-allow-credentials"] == "true"
+
+
+def test_cors_preflight_rejects_unconfigured_origin():
+    resp = client.options(
+        "/notes",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "access-control-allow-origin" not in resp.headers
 
 
 def test_register():


### PR DESCRIPTION
Implements #7.

Run: `issue-7-20260427-112352-cors-allows-all-origins-with-credentials`

Summary:
Implemented the CORS fix with a small scoped patch.

Changed:
- `config.py`: added comma-separated `ALLOWED_ORIGINS` env parsing with local dev defaults.
- `app.py`: `CORSMiddleware` now uses `ALLOWED_ORIGINS` instead of `["*"]`.
- `tests/test_app.py`: added regression coverage for middleware config, allowed preflight, and disallowed preflight.
- `.env.example` / `README.md`: documented `ALLOWED_ORIGINS`.

Verification:
- `tests/test_app.py`: 7 passed.
- `git diff --check`: passed.
- insecure pattern check for `allow_origins=["*"]` / `allow_origins=['*']` in `app.py`: no matches.
- Note: pinned dependency install was blocked here (`uv` panic, pip proxy 403), so I ran tests with the locally available Python/FastAPI environment after initializing the SQLite schema.

Worktree has the patch applied; no commits or pushes were made. Existing untracked `.gg-cache/` was left untouched.

Verification artifact: `.gg/runs/issue-7-20260427-112352-cors-allows-all-origins-with-credentials/artifacts/integration-verification.json`
